### PR TITLE
task: Add new value to CategoriesIdentifywith

### DIFF
--- a/etl/schemas/mission_impact_table_schema.json
+++ b/etl/schemas/mission_impact_table_schema.json
@@ -214,7 +214,7 @@
       "allows_multiple": true,
       "constraints": {
         "minimum": 1,
-        "maximum": 8
+        "maximum": 9
       },
       "enum_mapping": {
         "History of Substance Abuse": 1,
@@ -224,7 +224,8 @@
         "Immigrant": 5,
         "Refugee": 6,
         "LGBTQ": 7,
-        "Single Parent": 8
+        "Single Parent": 8,
+        "Other Condition": 9
       },
       "milestones": [
         0


### PR DESCRIPTION
This PR responds to feedback from South Bend Goodwill, whose data uses `9` as a value in CategoriesIdentifyWith. This PR fulfills the second step described here:
https://github.com/GIIMSC/goodwilldatainitiative-etl/tree/master/etl/schemas#adding-a-new-value