### PR TITLE
fix: Use correct variable name in sftp data rewrite

### DIFF
--- a/etl/helpers/sftp.py
+++ b/etl/helpers/sftp.py
@@ -46,7 +46,7 @@ def extract_data(
             raw_df, member_id, start_date, execution_date
         )
 
-        # Re-write file.
-        data.to_csv(tf.name, index=False)
+        # Re-write file with filtered dates.
+        data.to_csv(filename, index=False)
 
     return filenames


### PR DESCRIPTION
# Description
This PR fixes a critical (though seemingly small) issue in `sftp.extract_data`. 

`sftp.extract_data` does the following:
1. copies files from the sftp server into tempfiles.
2. iterates over each file, and filters out non-current data
3. rewrites the filtered data to the existing tempfile. 

The issue? The filtered data was being rewritten to `tf.name`, a variable that referred to the tempfile defined on line 38. That is, all data was being written to _the same file_, so data from one file simply overwrote data from another file. 