### PR TITLE
Dedupe hive 984

### DIFF
--- a/etl/helpers/data_processor.py
+++ b/etl/helpers/data_processor.py
@@ -468,7 +468,7 @@ class DataProcessor:
         df, dropped_duplicate_rows = self._drop_duplicates(df)
         for ind, dropped_row in dropped_duplicate_rows.iterrows():
             logging.error(
-                f"Dropping row {ind} due to duplicate values in the uploaded file"
+                f"Dropping row with CaseNumber {dropped_row['CaseNumber']} due to duplicate values in the uploaded file"
             )
             self.dropped_rows.append({ROW_KEY: dropped_row, DUPLICATE_ROWS_KEY: True})
 

--- a/etl/helpers/data_processor.py
+++ b/etl/helpers/data_processor.py
@@ -25,6 +25,7 @@ ORIGINAL_VALUE_KEY = "original_value"
 INVALID_REASON_KEY = "invalid_reasons"
 
 MISSING_FIELDS_KEY = "missing_fields"
+DUPLICATE_ROWS_KEY = "duplicate_rows"
 ROW_KEY = "row"
 
 
@@ -392,6 +393,27 @@ class DataProcessor:
         """Returns all required fields that are missing in a row."""
         return [f for f in required_fields if row[f] is BLANK_VALUE]
 
+    def _drop_duplicates(self, dataset):
+        """Returns a DataFrame with duplicate records removed and a DataFrame with the first instance of
+        each duplicate record.
+
+        GII defines 'duplicate' as records with the same CaseNumber, MilestoneFlag, and MemberOrganization.
+        """
+        logging.info(f"Length of dataset *before* dedupe: {dataset.shape[0]}")
+
+        dataset_deduped = dataset.drop_duplicates(
+            keep=False, subset=["CaseNumber", "MilestoneFlag", "MemberOrganization"]
+        ).reset_index(drop=True)
+        dropped_rows = dataset[
+            dataset.duplicated(
+                subset=["CaseNumber", "MilestoneFlag", "MemberOrganization"]
+            )
+        ].reset_index(drop=True)
+
+        logging.info(f"Length of dataset *after* dedupe: {dataset_deduped.shape[0]}")
+
+        return dataset_deduped, dropped_rows
+
     def process(self, dataset):
         """Transforms and validates the entire Dataframe.
         Expects dataframe to contain all required columns and no columns outside of the
@@ -421,12 +443,10 @@ class DataProcessor:
             else:
                 self._process_column(df, column_name)
 
-        # Drop any rows where required columns are missing
+        # Drop any rows where required columns are missing, and record dropped rows.
         # Note: If BLANK_VALUE is changed to not be None, this will break.
         null_rows = df[df[required_fields].isnull().any(axis=1)]
         df = df.dropna(subset=required_fields).reset_index(drop=True)
-
-        # Record dropped rows.
         for ind, new_row in null_rows.iterrows():
             # Get all invalid required fields for this row.
             missing_fields = self._get_invalid_required_fields(new_row, required_fields)
@@ -442,6 +462,14 @@ class DataProcessor:
                 },
             )
             self.dropped_rows.append({ROW_KEY: row, MISSING_FIELDS_KEY: missing_fields})
+
+        # Drop duplicates, and record dropped rows.
+        df, dropped_duplicate_rows = self._drop_duplicates(df)
+        for ind, dropped_row in dropped_duplicate_rows.iterrows():
+            logging.error(
+                f"Dropping row {ind} due to duplicate values in the uploaded file"
+            )
+            self.dropped_rows.append({ROW_KEY: dropped_row, DUPLICATE_ROWS_KEY: True})
 
         # Process the non-required columns.
         non_required_columns = (

--- a/etl/helpers/data_processor.py
+++ b/etl/helpers/data_processor.py
@@ -404,9 +404,10 @@ class DataProcessor:
         dataset_deduped = dataset.drop_duplicates(
             keep=False, subset=["CaseNumber", "MilestoneFlag", "MemberOrganization"]
         ).reset_index(drop=True)
+
         dropped_rows = dataset[
             dataset.duplicated(
-                subset=["CaseNumber", "MilestoneFlag", "MemberOrganization"]
+                keep=False, subset=["CaseNumber", "MilestoneFlag", "MemberOrganization"]
             )
         ].reset_index(drop=True)
 

--- a/etl/helpers/dataset_shape.py
+++ b/etl/helpers/dataset_shape.py
@@ -270,18 +270,6 @@ class GatewayDatasetShapeTransformer:
             self._convert_multiple_val(l) for l in dataset[column_name]
         ]
 
-    def _drop_old_duplicates(self, dataset):
-        logging.info(f"Length of dataset *before* dedupe: {dataset.shape[0]}")
-
-        dataset = dataset.sort_values(by=["Date"], ascending=False)
-        dataset = dataset.drop_duplicates(
-            subset=["CaseNumber", "MilestoneFlag", "MemberOrganization"]
-        ).reset_index(drop=True)
-
-        logging.info(f"Length of dataset *after* dedupe: {dataset.shape[0]}")
-
-        return dataset
-
     def transform_dataset_shape(self, dataset: pd.DataFrame) -> pd.DataFrame:
         if dataset.empty:
             return dataset
@@ -295,7 +283,5 @@ class GatewayDatasetShapeTransformer:
 
         for column_name in multiple_val_schema_cols:
             self._reformat_multiple_val_col(dataset, column_name)
-
-        dataset = self._drop_old_duplicates(dataset)
 
         return dataset

--- a/etl/helpers/email.py
+++ b/etl/helpers/email.py
@@ -73,6 +73,8 @@ def format_dropped_rows(dropped_rows):
 
         if row_info.get(MISSING_INTAKE_RECORD_KEY):
             message += "Dropped because the row does not have a corresponding 'Intake' record in the GII MIP database</li>"
+        elif row_info.get(data_processor.DUPLICATE_ROWS_KEY):
+            message += "Dropped because the uploaded data has duplicate instances of this record. Duplicate records have the same MileStoneFlag, CaseNumber, and MemberOrganization.</li>"
         else:
             message += "Dropped because of {}</li>".format(
                 ", ".join(_format_dropped_row_reasons(row_info))

--- a/etl/helpers/test_data_processor.py
+++ b/etl/helpers/test_data_processor.py
@@ -513,6 +513,46 @@ class TestDataProcessor(unittest.TestCase):
             ["rand", "rand", "rand", "rand", "rand"], output_df["RandomColumn"].tolist()
         )
 
+    def test_drop_duplicates(self):
+        input_dataframe = pd.DataFrame(
+            data={
+                "Date": ["2020-07-28", "2020-05-10", "2020-03-10", "2020-03-10"],
+                "CaseNumber": [
+                    "CASEID-000001",
+                    "CASEID-000003",
+                    "CASEID-xyzxyz",
+                    "CASEID-xyzxyz",
+                ],
+                "MilestoneFlag": ["SixtyDays", "SixtyDays", "Intake", "Intake"],
+                "MemberOrganization": ["abc", "abc", "abc", "abc"],
+            }
+        )
+
+        expected_deduped_dataframe = pd.DataFrame(
+            data={
+                "Date": ["2020-07-28", "2020-05-10"],
+                "CaseNumber": ["CASEID-000001", "CASEID-000003"],
+                "MilestoneFlag": ["SixtyDays", "SixtyDays"],
+                "MemberOrganization": ["abc", "abc"],
+            }
+        )
+
+        expected_dropped_records = pd.DataFrame(
+            data={
+                "Date": ["2020-03-10"],
+                "CaseNumber": ["CASEID-xyzxyz"],
+                "MilestoneFlag": ["Intake"],
+                "MemberOrganization": ["abc"],
+            }
+        )
+
+        dataset_deduped, dropped_records = self.processor._drop_duplicates(
+            input_dataframe
+        )
+
+        pd.util.testing.assert_frame_equal(expected_deduped_dataframe, dataset_deduped)
+        pd.util.testing.assert_frame_equal(expected_dropped_records, dropped_records)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/etl/helpers/test_data_processor.py
+++ b/etl/helpers/test_data_processor.py
@@ -516,15 +516,28 @@ class TestDataProcessor(unittest.TestCase):
     def test_drop_duplicates(self):
         input_dataframe = pd.DataFrame(
             data={
-                "Date": ["2020-07-28", "2020-05-10", "2020-03-10", "2020-03-10"],
+                "Date": [
+                    "2020-07-28",
+                    "2020-05-10",
+                    "2020-03-10",
+                    "2020-03-10",
+                    "2020-03-10",
+                ],
                 "CaseNumber": [
                     "CASEID-000001",
                     "CASEID-000003",
                     "CASEID-xyzxyz",
                     "CASEID-xyzxyz",
+                    "CASEID-xyzxyz",
                 ],
-                "MilestoneFlag": ["SixtyDays", "SixtyDays", "Intake", "Intake"],
-                "MemberOrganization": ["abc", "abc", "abc", "abc"],
+                "MilestoneFlag": [
+                    "SixtyDays",
+                    "SixtyDays",
+                    "Intake",
+                    "Intake",
+                    "Intake",
+                ],
+                "MemberOrganization": ["abc", "abc", "abc", "abc", "abc"],
             }
         )
 
@@ -539,10 +552,10 @@ class TestDataProcessor(unittest.TestCase):
 
         expected_dropped_records = pd.DataFrame(
             data={
-                "Date": ["2020-03-10"],
-                "CaseNumber": ["CASEID-xyzxyz"],
-                "MilestoneFlag": ["Intake"],
-                "MemberOrganization": ["abc"],
+                "Date": ["2020-03-10", "2020-03-10", "2020-03-10"],
+                "CaseNumber": ["CASEID-xyzxyz", "CASEID-xyzxyz", "CASEID-xyzxyz"],
+                "MilestoneFlag": ["Intake", "Intake", "Intake"],
+                "MemberOrganization": ["abc", "abc", "abc"],
             }
         )
 

--- a/etl/helpers/test_dataset_shape.py
+++ b/etl/helpers/test_dataset_shape.py
@@ -456,33 +456,6 @@ class GatewayDatasetShapeTransformerTest(unittest.TestCase):
             expected_shaped_dataset, actual_shaped_dataset
         )
 
-    def test_transform_dataset_shape_deduplicates_dataframe(self):
-        dataset = pd.DataFrame(
-            data={
-                "Date": ["2019-12-28", "2019-11-10", "2019-12-31", "2020-1-25"],
-                "CaseNumber": ["1", "2", "duplicate", "duplicate"],
-                "MilestoneFlag": ["3", "4", "duplicate", "duplicate"],
-                "MemberOrganization": ["abc", "def", "duplicate", "duplicate"],
-            }
-        )
-
-        actual_shaped_dataset = dataset_shape.GatewayDatasetShapeTransformer(
-            TEST_SCHEMA
-        ).transform_dataset_shape(dataset)
-
-        expected_shaped_dataset = pd.DataFrame(
-            data={
-                "Date": ["2020-1-25", "2019-12-28", "2019-11-10"],
-                "CaseNumber": ["duplicate", "1", "2"],
-                "MilestoneFlag": ["duplicate", "3", "4"],
-                "MemberOrganization": ["duplicate", "abc", "def"],
-            }
-        )
-
-        pd.util.testing.assert_frame_equal(
-            expected_shaped_dataset, actual_shaped_dataset
-        )
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/etl/helpers/test_email.py
+++ b/etl/helpers/test_email.py
@@ -105,9 +105,9 @@ class EmailTest(unittest.TestCase):
     def test_format_dropped_rows(self):
         test_dataframe = pd.DataFrame(
             {
-                "MilestoneFlag": ["Intake", None, "Exit"],
-                "MemberOrganization": ["aaa-111", "aaa-111", "aaa-111"],
-                "HourlyWage": ["$8.8", "$10.10", "$12.12"],
+                "MilestoneFlag": ["Intake", None, "Exit", "Intake"],
+                "MemberOrganization": ["aaa-111", "aaa-111", "aaa-111", "aaa-111"],
+                "HourlyWage": ["$8.8", "$10.10", "$12.12", "$9.19"],
             }
         )
 
@@ -124,12 +124,17 @@ class EmailTest(unittest.TestCase):
                 data_processor.ROW_KEY: test_dataframe.loc[2],
                 MISSING_INTAKE_RECORD_KEY: True,
             },
+            {
+                data_processor.ROW_KEY: test_dataframe.loc[3],
+                data_processor.DUPLICATE_ROWS_KEY: True,
+            },
         ]
 
         self.assertEqual(
             "<ul><li><i>(CaseNumber: 'None', MilestoneFlag: 'Intake')</i> Dropped because of CaseNumber (missing)</li>"
             + "<li><i>(CaseNumber: 'None', MilestoneFlag: 'None')</i> Dropped because of MilestoneFlag (missing), CaseNumber (missing)</li>"
-            + "<li><i>(CaseNumber: 'None', MilestoneFlag: 'Exit')</i> Dropped because the row does not have a corresponding 'Intake' record in the GII MIP database</li></ul>",
+            + "<li><i>(CaseNumber: 'None', MilestoneFlag: 'Exit')</i> Dropped because the row does not have a corresponding 'Intake' record in the GII MIP database</li>"
+            + "<li><i>(CaseNumber: 'None', MilestoneFlag: 'Intake')</i> Dropped because the uploaded data has duplicate instances of this record. Duplicate records have the same MileStoneFlag, CaseNumber, and MemberOrganization.</li></ul>",
             email.format_dropped_rows(dropped_rows),
         )
 

--- a/etl/pipeline/test_simple_pipeline.py
+++ b/etl/pipeline/test_simple_pipeline.py
@@ -10,6 +10,7 @@ import pandas as pd
 from typing import Dict
 
 from etl.pipeline import simple_pipeline
+from etl.helpers.data_processor import DUPLICATE_ROWS_KEY
 
 MEMBER_ID = "member_id"
 MULTIPLE_VAL_DELIMITER = ";"
@@ -51,14 +52,30 @@ class TestPipeline(unittest.TestCase):
         resolved_field_mappings = pipeline_return_vals["field_mappings"]
         self.assertIsInstance(resolved_field_mappings, Dict)
 
-        # fake_data.csv contains six rows (with two duplicates), and so, we expect only four rows in 'num_rows_to_upload'.
-        assert pipeline_return_vals["email_metadata"]["num_rows_to_upload"] == 4
-        assert pipeline_return_vals["email_metadata"]["dropped_rows"] == []
+        # fake_data.csv contains six rows (with two pairs of duplicates), and so, we expect only two rows in 'num_rows_to_upload'.
+        assert pipeline_return_vals["email_metadata"]["num_rows_to_upload"] == 2
         assert pipeline_return_vals["email_metadata"]["dropped_values"] == []
-
-        expected_case_nums = pd.Series(
-            ["CASEID-000001", "CASEID-000002", "CASEID-000004", "CASEID-000003"]
+        assert len(pipeline_return_vals["email_metadata"]["dropped_rows"]) == 2
+        assert (
+            pipeline_return_vals["email_metadata"]["dropped_rows"][0]["row"][
+                "CaseNumber"
+            ]
+            == "CASEID-000002"
         )
+        assert pipeline_return_vals["email_metadata"]["dropped_rows"][0][
+            DUPLICATE_ROWS_KEY
+        ]
+        assert (
+            pipeline_return_vals["email_metadata"]["dropped_rows"][1]["row"][
+                "CaseNumber"
+            ]
+            == "CASEID-000004"
+        )
+        assert pipeline_return_vals["email_metadata"]["dropped_rows"][1][
+            DUPLICATE_ROWS_KEY
+        ]
+
+        expected_case_nums = pd.Series(["CASEID-000001", "CASEID-000003"])
         case_nums = pipeline_return_vals["dataset"]["CaseNumber"]
         pd.testing.assert_series_equal(case_nums, expected_case_nums, check_names=False)
 

--- a/etl/pipeline/test_simple_pipeline.py
+++ b/etl/pipeline/test_simple_pipeline.py
@@ -55,7 +55,7 @@ class TestPipeline(unittest.TestCase):
         # fake_data.csv contains six rows (with two pairs of duplicates), and so, we expect only two rows in 'num_rows_to_upload'.
         assert pipeline_return_vals["email_metadata"]["num_rows_to_upload"] == 2
         assert pipeline_return_vals["email_metadata"]["dropped_values"] == []
-        assert len(pipeline_return_vals["email_metadata"]["dropped_rows"]) == 2
+        assert len(pipeline_return_vals["email_metadata"]["dropped_rows"]) == 4
         assert (
             pipeline_return_vals["email_metadata"]["dropped_rows"][0]["row"][
                 "CaseNumber"
@@ -66,12 +66,12 @@ class TestPipeline(unittest.TestCase):
             DUPLICATE_ROWS_KEY
         ]
         assert (
-            pipeline_return_vals["email_metadata"]["dropped_rows"][1]["row"][
+            pipeline_return_vals["email_metadata"]["dropped_rows"][2]["row"][
                 "CaseNumber"
             ]
             == "CASEID-000004"
         )
-        assert pipeline_return_vals["email_metadata"]["dropped_rows"][1][
+        assert pipeline_return_vals["email_metadata"]["dropped_rows"][2][
             DUPLICATE_ROWS_KEY
         ]
 


### PR DESCRIPTION
# Description

This PR adjusts the deduplication logic. Previously, the `dataset_shape` actually deduplicated the dataframe; however, this does not always work as expected (see: Tacoma). Rather than deduplicating, the `dataset_processor` drops _all_ duplicate records and returns line items in the email.